### PR TITLE
Fixed minor varchar length issue in DB

### DIFF
--- a/src/main/java/com/codingnomads/betty/data/models/Tweet.java
+++ b/src/main/java/com/codingnomads/betty/data/models/Tweet.java
@@ -13,8 +13,7 @@ public class Tweet {
     private Long id;
     @Size(max = 15)
     private String language;
-    @NotBlank()
-    @Size(max = 512)
+    @Column(length = 512)
     private String text;
     @NotBlank
     private String createdAt;


### PR DESCRIPTION
- Changed JPA maxed sized to 512
- (Not in code) forced VARCHAR(512) change to 'text' column in 'tweets' table to 512 too