### PR TITLE
Solved security vulnerabilities in front-end

### DIFF
--- a/src/main/resources/static/package-lock.json
+++ b/src/main/resources/static/package-lock.json
@@ -2253,7 +2253,7 @@
                         "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
-                        "tar": "^4"
+                        "tar": "^4.4.8"
                     }
                 },
                 "nopt": {
@@ -3538,8 +3538,8 @@
             "dev": true
         },
         "jquery": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
             "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
         },
         "js-base64": {
@@ -4166,7 +4166,7 @@
                 "request": "^2.87.0",
                 "rimraf": "2",
                 "semver": "~5.3.0",
-                "tar": "^2.0.0",
+                "tar": "^4.4.8",
                 "which": "1"
             },
             "dependencies": {
@@ -5901,8 +5901,8 @@
             "dev": true
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "version": "4.4.8",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {

--- a/src/main/resources/static/package.json
+++ b/src/main/resources/static/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "@fortawesome/fontawesome-free": "5.8.1",
         "bootstrap": "4.3.1",
-        "jquery": "3.3.1",
+        "jquery": "3.4.1",
         "simple-line-icons": "^2.4.1"
     },
     "devDependencies": {


### PR DESCRIPTION
It turns out the bootstrap template I used for the front-end, contained dependencies of old versions for 'tar' and 'jquery' which triggered security alerts in both Sonar and Github.
I have now changed the 'package-lock.json' file to include the most recent versions for both tar and jquery